### PR TITLE
Project should now build correctly with libc++ on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ PROJECT := pocketpower
 # Name of process the tweak is loaded into
 PROCESS := minecraftpe
 
-# Build using libc++ and C++11 support
-# Unfortunately these build parameters are set up just for me :(
-override CXXFLAGS += -stdlib=libstdc++ -std=c++11 -miphoneos-version-min=5.0 -isysroot /iPhoneOS8.1.sdk
-override LDFLAGS += -stdlib=libstdc++ -lc++ -lsubstrate -isysroot /iPhoneOS8.1.sdk
+# Directory of the iOS SDK on MacOS
+SDKROOT := /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+
+# Build using libc++ and C++11 support (for 12/24-byte strings and vectors)
+# This should be build on a Mac, since the iOS build environment does not work correctly when linking to libc++
+override CXXFLAGS += -stdlib=libc++ -std=c++11 -miphoneos-version-min=7.0 -isysroot $(SDKROOT)
+override LDFLAGS += -stdlib=libc++ -isysroot $(SDKROOT)
 
 
 # Names of the tweak library, substrate filter, and debian package
@@ -30,7 +33,7 @@ OBJS := $(addprefix $(BUILD)/,$(SRCS:.cpp=.o))
 ARCHS := armv7 arm64
 ARCHFLAGS := $(addprefix -arch ,$(ARCHS))
 # Frameworks for linking
-FRAMEWORKS := Forklift
+FRAMEWORKS := CydiaSubstrate Forklift
 override LDFLAGS += $(addprefix -framework ,$(FRAMEWORKS))
 
 # Compiler and linker

--- a/PocketPower.cpp
+++ b/PocketPower.cpp
@@ -1,6 +1,9 @@
-#include <substrate.h>
+// framework includes
+#include <CydiaSubstrate/CydiaSubstrate.h>
 #include <Forklift/Forklift.h>
+// standard includes
 #include <string>
+// local includes
 #include "addresses.h" 
 
 #include "mcpe/client/renderer/tile/TileTessellator.h"


### PR DESCRIPTION
The project should now be able to properly build on MacOS when linking against libc++. On iOS it could only be built with libstdc++ because libc++ support on iOS is incomplete and always yields linker errors. I have found a solution for this by building in MacOS, so I have changed the Makefile so that the project is intended to be built on MacOS only.

The usefulness of using libc++ is that MCPE on iOS is built using this STL. This means that if you were to make a mod using libstdc++ then the STLs would have incompatible string and vector types and would lead to runtime errors and crashes (PocketPower iOS uses a hacky bypass for this which is why none of the blocks have names). If a mod is instead built with libc++, then we should be able to properly use standard C++ types with MCPE and fix all of these problems.